### PR TITLE
Ground height and idle timeout improvements

### DIFF
--- a/Firmware-C/elev8-main.h
+++ b/Firmware-C/elev8-main.h
@@ -43,6 +43,9 @@ void All_LED( int Color );
 // #define ENABLE_PING_SENSOR
 // #define ENABLE_LASER_RANGE
 
+// define for PING/LASER, when enabled, requires Aux1 to be toggled to use sensor-based altitude hold
+// #define GROUND_HEIGHT_REQUIRE_AUX1
+
 
 #define EXTRA_LIGHTS
 


### PR DESCRIPTION
Made the use of Aux1 to enable ground height optional (and off by default) using a #ifdef.
Fixed the idle timeout code (prior version left it in an unsafe state after timeout).
