### PR TITLE
Altitude hold minor update

### DIFF
--- a/Firmware-C/elev8-main.h
+++ b/Firmware-C/elev8-main.h
@@ -42,6 +42,9 @@ void All_LED( int Color );
 // #define ENABLE_PING_SENSOR
 // #define ENABLE_LASER_RANGE
 
+// define for PING/LASER, when enabled, requires Aux1 to be toggled to use sensor-based altitude hold
+// #define GROUND_HEIGHT_REQUIRE_AUX1
+
 
 #define EXTRA_LIGHTS
 


### PR DESCRIPTION
Makes the requirement to toggle Aux1 for sensor-based altitude hold optional (and off by default)
